### PR TITLE
fix: ESP32-C5 support with pure-SRAM default and UART RX drop-on-disc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,13 @@ tools/linkr_ble_terminal_c
 *.log
 sbc-console*.txt
 sbc-console*.log
+log_*.txt
+
+# Debug/automation scratch files (serial monitor helpers, patches, etc.)
+.tmp_*
+
+# Local tooling state
+.reasonix/
 
 # macOS
 .DS_Store

--- a/Kconfig
+++ b/Kconfig
@@ -179,6 +179,19 @@ config LINKR_BLE_BRIDGE_TEST_UART_LOOPBACK_PAYLOAD
 	default "linkr-loopback-test"
 	depends on LINKR_BLE_BRIDGE_TEST_UART_LOOPBACK_VERIFY
 
+config LINKR_BLE_BRIDGE_UART_RX_DROP_NO_CONN
+	bool "Drop UART capture from the BLE path when no central is connected"
+	default n
+	help
+	  When no BLE central is connected, the Reliable UART path cannot
+	  deliver. With this option the UART-to-BLE thread discards the BLE
+	  delivery of each captured chunk instead of retrying it forever;
+	  the chunk is still staged for the WebSocket bridge and log ring.
+	  Without it, a chunk captured while disconnected is retried until a
+	  central reconnects, stalling the WebSocket bridge feed. Enable on
+	  targets that must support LAN-only (WebSocket) operation without an
+	  active BLE connection.
+
 config LINKR_BLE_BRIDGE_WIFI
 	bool
 	default y
@@ -215,6 +228,12 @@ config LINKR_BLE_BRIDGE_WIFI_RETRY_MS
 	  Delay before retrying a configured WiFi connection after a connection
 	  failure or disconnect.
 
+config LINKR_BLE_BRIDGE_WIFI_CONNECT_STACK
+	int "WiFi connect thread stack size"
+	default 8192
+	range 1024 16384
+	depends on LINKR_BLE_BRIDGE_WIFI
+
 config LINKR_BLE_BRIDGE_WEBDAV
 	bool "Enable WebDAV serial log upload"
 	default y
@@ -234,6 +253,15 @@ config LINKR_BLE_BRIDGE_WEBDAV_UPLOAD_CHUNK
 	default 4096
 	range 256 32768
 	depends on LINKR_BLE_BRIDGE_WEBDAV
+
+config LINKR_BLE_BRIDGE_LOG_RING_SIZE
+	int "WebDAV log staging ring buffer size in bytes"
+	default 8192
+	range 512 32768
+	depends on LINKR_BLE_BRIDGE_WEBDAV
+	help
+	  Bytes of UART RX data staged for periodic WebDAV upload. When the
+	  ring overflows, the oldest bytes are dropped and counted.
 
 config LINKR_BLE_BRIDGE_WIFI_SSID_MAX
 	int "Maximum WiFi SSID length"
@@ -309,6 +337,20 @@ config LINKR_BLE_BRIDGE_WS_BRIDGE_STACK
 	default 4096
 	range 1024 8192
 	depends on LINKR_BLE_BRIDGE_WS_BRIDGE
+
+config LINKR_BLE_BRIDGE_MGMT_TX_QUEUE_DEPTH
+	int "BLE management TX queue depth"
+	default 16
+	range 4 64
+	help
+	  Number of management TX messages that can wait for BLE transmission.
+	  Must hold a full WiFi scan burst (scan results plus the "done"
+	  line enqueued back to back).
+
+config LINKR_BLE_BRIDGE_MGMT_REQUEST_STACK
+	int "BLE management request thread stack size"
+	default 4096
+	range 1024 8192
 
 endmenu
 

--- a/boards/esp32c5_devkitc_esp32c5_hpcore.conf
+++ b/boards/esp32c5_devkitc_esp32c5_hpcore.conf
@@ -1,0 +1,150 @@
+# ESP32-C5 DevKitC board configuration overlay.
+#
+# C5 vs C3 differences that need Kconfig tuning:
+#  - 4 MB PSRAM on WROOM-1-N8R4 module (C3 has none)
+#  - Tighter internal SRAM (need dynamic mgmt RX, smaller UART/log buffers)
+#  - BLE controller memory sizing differs; cap advertising activity counts
+#  - WiFi driver may silently drop CONNECT_RESULT events; watchdog recovers
+#  - IPv6 stack is not needed (STA connects to IPv4-only hotspots); it also
+#    corrupts the IPv4 config slot pool on this target (see below)
+
+# --- PSRAM (default: disabled, pure SRAM) ---------------------------------
+# Pure SRAM variant: the WiFi heap is served from the locked kernel heap in
+# DRAM (ESP_WIFI_HEAP_SYSTEM -> k_malloc). Verified stable through repeated
+# WiFi connect/off/on cycles. SRAM usage is ~99.5% with this config, so the
+# debug instrumentation section below must stay commented out as well.
+# CONFIG_ESP_SPIRAM=n
+CONFIG_ESP_WIFI_HEAP_SYSTEM=y
+
+# PSRAM option (WROOM-1-N8R4 with 4 MB PSRAM): uncomment the three lines
+# below and comment CONFIG_ESP_WIFI_HEAP_SYSTEM above to move the WiFi heap
+# into PSRAM via shared_multi_heap. Note: the zephyr tree in use carries a
+# local patch adding a k_spinlock to shared_multi_heap.c (lib/heap/); without
+# it the unlocked concurrent allocation path corrupts heap metadata and
+# causes CPU_LOCKUP resets (see docs/PSRAM_HEAP_LOCKUP_FIX.md). The debug
+# instrumentation section below may then be re-enabled.
+# CONFIG_ESP_SPIRAM=y
+# CONFIG_ESP_WIFI_HEAP_SPIRAM=y
+# CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM=y
+
+# --- BLE controller limits (C5 memory model) ------------------------------
+CONFIG_ESP32_BT_CTLR_LE_MAX_CONN=1
+CONFIG_ESP32_BT_CTLR_LE_MAX_ACT=2
+CONFIG_ESP32_BT_LE_LL_DUP_SCAN_LIST_COUNT=5
+
+# --- Free internal SRAM ---------------------------------------------------
+CONFIG_LINKR_BLE_BRIDGE_UART_RX_BUFFER_SIZE=2048
+CONFIG_LINKR_BLE_BRIDGE_WS_BRIDGE_CLIENT_BUFFER_SIZE=1024
+CONFIG_ESP32_WIFI_DYNAMIC_RX_MGMT_BUFFER=y
+# Disable non-essential features to free SRAM for BLE debug logging
+#CONFIG_LINKR_BLE_BRIDGE_WS_BRIDGE=n
+
+# --- Thread stacks (sized from on-device watermarks) ----------------------
+# Measured high-water marks on the C5 target: http_server 1592 B (SHA1
+# handshake path), sysworkq 1264-1416 B (WiFi scan work, boot items),
+# wifi_connect 1320 B (connect + DHCP startup), mgmt_request 2140 B.
+# STACK_SENTINEL guards the margin. C3 targets keep the larger defaults,
+# which are unmeasured there.
+CONFIG_HTTP_SERVER_STACK_SIZE=4096
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+CONFIG_LINKR_BLE_BRIDGE_WIFI_CONNECT_STACK=4096
+CONFIG_LINKR_BLE_BRIDGE_MGMT_REQUEST_STACK=3072
+# ws_bridge per-client thread: measured watermark 1572 B (sampled while a
+# WS client is connected).
+CONFIG_LINKR_BLE_BRIDGE_WS_BRIDGE_STACK=3072
+
+# --- App buffers (sized from measured traffic) ----------------------------
+# log_ring stages two WebDAV upload chunks; mgmt tx_queue must hold a full
+# WiFi scan burst (12 results + done = 13 messages), measured high-water
+# mark 12 with drops=0. C3 keeps the larger defaults.
+CONFIG_LINKR_BLE_BRIDGE_LOG_RING_SIZE=2048
+CONFIG_LINKR_BLE_BRIDGE_MGMT_TX_QUEUE_DEPTH=13
+# Upload chunk sized to half a log_ring fill; larger chunks only extend
+# the PUT latency on this target.
+CONFIG_LINKR_BLE_BRIDGE_WEBDAV_UPLOAD_CHUNK=1024
+
+# --- Logging (immediate mode saves SRAM; smaller buffer) ------------------
+CONFIG_LOG_MODE_IMMEDIATE=y
+CONFIG_LOG_BUFFER_SIZE=4096
+
+# --- BLE coexistence with WiFi ---------------------------------------------
+# Observed on C5: @w=ssid,pass triggers a WiFi scan/connect window during
+# which the single radio is held by WiFi; the BLE link receives nothing for
+# several seconds and drops with reason 0x08 (connection timeout) ~5 s after
+# the connect request. The default peripheral-preferred supervision timeout
+# is 42 x 10 ms = 420 ms, far below the WiFi radio-blackout window. Request
+# 8 s so the link survives scan + association + 4-way handshake. C3 boards
+# keep the default (shorter scans, no observed 0x08).
+CONFIG_BT_PERIPHERAL_PREF_TIMEOUT=800
+
+# --- BLE info logging (key events only, diagnose 0x08 connection timeout) ---
+CONFIG_BT_LOG_LEVEL_INF=y
+CONFIG_BT_CONN_LOG_LEVEL_INF=y
+CONFIG_BT_HCI_CORE_LOG_LEVEL_INF=y
+
+# --- LAN-only (WebSocket) operation ----------------------------------------
+# The C5 target must serve the UART over the WS bridge while no BLE central
+# is connected. Without this, a UART chunk captured while disconnected is
+# retried forever on the Reliable UART path, stalling the UART RX thread and
+# starving the WS bridge feed (observed: LAN TX counters grow, RX stays 0).
+CONFIG_LINKR_BLE_BRIDGE_UART_RX_DROP_NO_CONN=y
+
+# --- WiFi Recovery --------------------------------------------------------
+CONFIG_LINKR_BLE_BRIDGE_WIFI_RETRY_MS=3000
+
+# --- IPv4-only stack -------------------------------------------------------
+# IPv6 is not used on the C5 target. Disabling it removes ipv6_addresses[],
+# MLD/ND/DAD and shrinks per-address state; the IPv6 init path was found to
+# write IPv6-style records (ff01:: mcast groups, AF_INET6) over the adjacent
+# ipv4_addresses[] pool, so DHCP could never claim a config slot.
+CONFIG_NET_IPV6=n
+
+# The DHCPv6 DNS options depend only on DNS_RESOLVER, so they survive
+# NET_IPV6=n as dead defaults; disable them for a strictly IPv4 stack.
+CONFIG_NET_DHCPV6_OPTION_DNS_ADDRESS=n
+CONFIG_NET_DHCPV6_DNS_SERVER_VIA_INTERFACE=n
+
+# --- DHCP ----------------------------------------------------------------
+CONFIG_NET_DHCPV4_INITIAL_DELAY_MAX=2
+CONFIG_NET_IF_MAX_IPV4_COUNT=2
+
+# --- Debug: heap corruption instrumentation ------------------------------
+# Kept commented out by default: with the pure SRAM variant above, enabling
+# this section overflows SRAM by ~1792 bytes at link time. Re-enable it when
+# building with PSRAM.
+#
+# Observed failure signature on C5: "WiFi connected" -> "WS bridge start" ->
+# "WiFi IPv4 address ready" followed by system freeze; one occurrence reset
+# with rst:0x1a (CPU_LOCKUP), Core0 Saved PC decoded to chunk_set()
+# (zephyr/lib/heap/heap.h), i.e. the sys_heap allocator spinning on
+# corrupted heap metadata. SYS_HEAP_VALIDATE checks every heap on each
+# alloc/free so the corruption is caught at the first offending call
+# instead of much later inside the allocator. C3 builds are unaffected.
+#CONFIG_SYS_HEAP_VALIDATE=y
+#CONFIG_THREAD_STACK_INFO=y
+#CONFIG_STACK_SENTINEL=y
+
+# Round 2 instrumentation: after reproducing with SYS_HEAP_VALIDATE on,
+# the freeze recurred without any heap validation panic, and the board was
+# still functional over BLE/UART while the network dataplane (ping/TCP)
+# and the log/console output were frozen. The corrupted memory is therefore
+# not sys_heap-managed. Thread analyzer dumps thread states periodically
+# via printk (direct console path) so the frozen thread(s) can be identified
+# after the fault. Net stack logging traces the last events before freeze.
+#CONFIG_THREAD_ANALYZER=y
+#CONFIG_THREAD_ANALYZER_USE_PRINTK=y
+#CONFIG_THREAD_ANALYZER_AUTO=y
+#CONFIG_THREAD_ANALYZER_AUTO_INTERVAL=30
+#CONFIG_THREAD_ANALYZER_AUTO_STACK_SIZE=2048
+#CONFIG_NET_LOG=y
+#CONFIG_NET_CORE_LOG_LEVEL_DBG=y
+#CONFIG_NET_IF_LOG_LEVEL_DBG=y
+#CONFIG_NET_DHCPV4_LOG_LEVEL_DBG=y
+
+# Round 3: the fault reproduced as "every incoming frame discarded by L2"
+# right after IPv4 becomes ready while all threads stay alive. Enable the
+# ethernet L2 debug logs to capture the exact drop reason ("not for me" vs
+# "unknown hdr type"), which distinguishes a corrupted interface link
+# address from a corrupted ethertype/header.
+#CONFIG_NET_L2_ETHERNET_LOG_LEVEL_DBG=y
+#CONFIG_NET_ARP_LOG_LEVEL_DBG=y

--- a/boards/esp32c5_devkitc_esp32c5_hpcore.overlay
+++ b/boards/esp32c5_devkitc_esp32c5_hpcore.overlay
@@ -1,0 +1,75 @@
+/ {
+	chosen {
+		zephyr,linkr-ble-uart = &uart1;
+		zephyr,console = &usb_serial;
+		zephyr,shell-uart = &usb_serial;
+	};
+
+	aliases {
+		linkr-factory-reset = &linkr_factory_reset;
+	};
+
+	linkr_factory_reset_keys {
+		compatible = "gpio-keys";
+
+		/* Hold GPIO28 low (short to GND) during boot to reset ownership.
+		 * GPIO28 is the BOOT button on ESP32-C5 DevKitC. */
+		linkr_factory_reset: factory-reset {
+			label = "Linkr factory reset";
+			gpios = <&gpio0 28 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+	};
+};
+
+/* UART0 on GPIO11/12 (board default) is disabled; UART1 takes those pins. */
+&uart0 {
+	status = "disabled";
+};
+
+/* UART1 on GPIO11(TX)/GPIO12(RX) — bridge serial, matching the
+ * 14_wireless_serial_webserver example's convention. */
+&uart1 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-names = "default";
+};
+
+&pinctrl {
+	uart1_default: uart1_default {
+		group1 {
+			pinmux = <UART1_TX_GPIO11>;
+			output-high;
+		};
+		group2 {
+			pinmux = <UART1_RX_GPIO12>;
+			bias-pull-up;
+		};
+	};
+};
+
+/* Shrink storage partition by 4K to make room for the firmware-test marker,
+ * keeping it out of the default coredump sector. */
+&storage_partition {
+	reg = <0x7b0000 0x2f000>;
+};
+
+&flash0 {
+	partitions {
+		linkr_test_marker_partition: partition@7df000 {
+			label = "linkr-test-marker";
+			reg = <0x7df000 0x1000>;
+		};
+	};
+};
+
+/* Enable the onboard WiFi node used by the single Linkr firmware. */
+&wifi {
+	status = "okay";
+};
+
+/* Use USB Serial/JTAG (built-in USB-C port) for console output.
+ * UART0 (GPIO11/12) is reserved for the bridge UART1. */
+&usb_serial {
+	status = "okay";
+};

--- a/src/ble_mgmt.c
+++ b/src/ble_mgmt.c
@@ -23,7 +23,11 @@ LOG_MODULE_REGISTER(linkr_ble_mgmt, LOG_LEVEL_INF);
 
 #define LINKR_MGMT_RX_TIMEOUT_MS 2000
 #define LINKR_MGMT_REQUEST_QUEUE_DEPTH 2
-#define LINKR_MGMT_TX_QUEUE_DEPTH 16
+/* A WiFi scan burst enqueues at most WIFI_SCAN_MAX_RESULTS results plus
+ * the "done" line back to back (13 messages); the measured high-water mark
+ * on the C5 target was 12, so the board overlay trims the default to just
+ * enough for the full burst. */
+#define LINKR_MGMT_TX_QUEUE_DEPTH CONFIG_LINKR_BLE_BRIDGE_MGMT_TX_QUEUE_DEPTH
 #define LINKR_MGMT_INDICATE_TIMEOUT_MS 5000
 #define LINKR_MGMT_FRAGMENT_MAX 244
 
@@ -375,7 +379,10 @@ static void tx_thread(void)
 	}
 }
 
-K_THREAD_DEFINE(linkr_mgmt_request_tid, 4096, request_thread,
+/* On the C5 target the measured high-water mark is 2140 B, so the
+ * board overlay trims the default; STACK_SENTINEL guards the margin. */
+K_THREAD_DEFINE(linkr_mgmt_request_tid,
+		CONFIG_LINKR_BLE_BRIDGE_MGMT_REQUEST_STACK, request_thread,
 		NULL, NULL, NULL, 7, 0, 0);
 K_THREAD_DEFINE(linkr_mgmt_tx_tid, 2048, tx_thread,
 		NULL, NULL, NULL, 7, 0, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -1388,7 +1388,17 @@ static int uart_forward_chunk(const uint8_t *data, uint16_t len,
 	}
 
 	err = reliable_send_chunk(data, len);
-	if (err && err != -ENOTCONN) {
+	if (err == -ENOTCONN) {
+		if (IS_ENABLED(CONFIG_LINKR_BLE_BRIDGE_UART_RX_DROP_NO_CONN)) {
+			/* LAN-only operation: with no BLE central the reliable
+			 * path can never deliver, and retrying forever stalls
+			 * this thread, which then stops feeding the WebSocket
+			 * bridge and the log ring. The chunk was already staged
+			 * above; drop it from the BLE path and keep draining.
+			 */
+			return 0;
+		}
+	} else if (err) {
 		LOG_WRN("Reliable UART delivery retry: %d", err);
 	}
 	return err;

--- a/src/main.c
+++ b/src/main.c
@@ -140,6 +140,7 @@ static struct {
 } mgmt_capture;
 #if !IS_ENABLED(CONFIG_LINKR_BLE_BRIDGE_TEST_UART_LOOPBACK_VERIFY)
 static atomic_t uart_rx_dropped;
+static atomic_t uart_reliable_drop_no_conn;
 #endif
 static struct uart_config active_uart_config = {
 	.baudrate = CONFIG_LINKR_BLE_BRIDGE_UART_BAUD_RATE,
@@ -862,11 +863,13 @@ static void diagnostics_response(struct bt_conn *conn)
 {
 	char status[192];
 	uint32_t dropped = 0;
+	uint32_t dropped_no_conn = 0;
 	uint32_t buffered = ring_buf_size_get(&uart_rx_ring);
 	bt_security_t security = bt_conn_get_security(conn);
 
 #if !IS_ENABLED(CONFIG_LINKR_BLE_BRIDGE_TEST_UART_LOOPBACK_VERIFY)
 	dropped = (uint32_t)atomic_get(&uart_rx_dropped);
+	dropped_no_conn = (uint32_t)atomic_get(&uart_reliable_drop_no_conn);
 #endif
 	(void)send_control_response(conn, "@info fw version=%s zephyr=%s\r\n",
 				    CONFIG_LINKR_BLE_BRIDGE_FIRMWARE_VERSION,
@@ -876,8 +879,8 @@ static void diagnostics_response(struct bt_conn *conn)
 				    (long long)k_uptime_get(), 0U,
 				    (unsigned int)security);
 	(void)send_control_response(conn,
-				    "@info uart dropped=%u buffer=%u/%u\r\n",
-				    dropped, buffered, UART_RX_BUFFER_SIZE);
+				    "@info uart dropped=%u dropped_no_conn=%u buffer=%u/%u\r\n",
+				    dropped, dropped_no_conn, buffered, UART_RX_BUFFER_SIZE);
 
 	(void)linkr_wifi_diagnostics(status, sizeof(status));
 	(void)send_control_response(conn, "@info wifi %s\r\n", status);
@@ -1390,6 +1393,7 @@ static int uart_forward_chunk(const uint8_t *data, uint16_t len,
 	err = reliable_send_chunk(data, len);
 	if (err == -ENOTCONN) {
 		if (IS_ENABLED(CONFIG_LINKR_BLE_BRIDGE_UART_RX_DROP_NO_CONN)) {
+			atomic_inc(&uart_reliable_drop_no_conn);
 			/* LAN-only operation: with no BLE central the reliable
 			 * path can never deliver, and retrying forever stalls
 			 * this thread, which then stops feeding the WebSocket

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -44,7 +44,11 @@ LOG_MODULE_REGISTER(linkr_wifi, CONFIG_LOG_DEFAULT_LEVEL);
 #define PSK_MAX    CONFIG_LINKR_BLE_BRIDGE_WIFI_PSK_MAX
 #define URL_MAX    CONFIG_LINKR_BLE_BRIDGE_WEBDAV_URL_MAX
 #define CRED_MAX   CONFIG_LINKR_BLE_BRIDGE_WEBDAV_CRED_MAX
-#define LOG_RING_SIZE 8192
+/* Staging for periodic WebDAV upload, drained every
+ * CONFIG_LINKR_BLE_BRIDGE_WEBDAV_UPLOAD_INTERVAL_MS; older bytes are
+ * dropped and counted (see log_dropped_bytes). The ESP32-C5 board
+ * overlay trims the default to two upload chunks. */
+#define LOG_RING_SIZE CONFIG_LINKR_BLE_BRIDGE_LOG_RING_SIZE
 #define SETTINGS_MAGIC 0x4c4e4b52u /* "LNKR" */
 #define SETTINGS_VERSION 1u
 /* Leaves room for the completion marker in the control-response queue. */
@@ -439,7 +443,10 @@ static int advance_log_boot_id(void)
     return 0;
 }
 
-#define WIFI_CONNECT_STACK  8192
+/* On the C5 target the measured high-water mark is 1320 B (connect +
+ * DHCP startup path), so the board overlay trims the default;
+ * STACK_SENTINEL guards the margin. */
+#define WIFI_CONNECT_STACK  CONFIG_LINKR_BLE_BRIDGE_WIFI_CONNECT_STACK
 #define WIFI_CONNECT_PRIO   10
 
 struct wifi_connect_msg {

--- a/src/wifi.c
+++ b/src/wifi.c
@@ -48,7 +48,17 @@ LOG_MODULE_REGISTER(linkr_wifi, CONFIG_LOG_DEFAULT_LEVEL);
  * CONFIG_LINKR_BLE_BRIDGE_WEBDAV_UPLOAD_INTERVAL_MS; older bytes are
  * dropped and counted (see log_dropped_bytes). The ESP32-C5 board
  * overlay trims the default to two upload chunks. */
+#if IS_ENABLED(CONFIG_LINKR_BLE_BRIDGE_WEBDAV)
 #define LOG_RING_SIZE CONFIG_LINKR_BLE_BRIDGE_LOG_RING_SIZE
+#define WEBDAV_UPLOAD_CHUNK CONFIG_LINKR_BLE_BRIDGE_WEBDAV_UPLOAD_CHUNK
+#define WEBDAV_UPLOAD_INTERVAL_MS CONFIG_LINKR_BLE_BRIDGE_WEBDAV_UPLOAD_INTERVAL_MS
+#else
+/* Keep the module buildable when WEBDAV is disabled, even if upload
+ * settings are not generated. */
+#define LOG_RING_SIZE CONFIG_LINKR_BLE_BRIDGE_UART_RX_BUFFER_SIZE
+#define WEBDAV_UPLOAD_CHUNK 512
+#define WEBDAV_UPLOAD_INTERVAL_MS 1000
+#endif
 #define SETTINGS_MAGIC 0x4c4e4b52u /* "LNKR" */
 #define SETTINGS_VERSION 1u
 /* Leaves room for the completion marker in the control-response queue. */
@@ -1265,13 +1275,13 @@ static void upload_thread(void *a, void *b, void *c)
     ARG_UNUSED(b);
     ARG_UNUSED(c);
 
-    static uint8_t chunk[CONFIG_LINKR_BLE_BRIDGE_WEBDAV_UPLOAD_CHUNK];
+    static uint8_t chunk[WEBDAV_UPLOAD_CHUNK];
     size_t pending_total = 0;
     uint32_t pending_sequence = 0;
     uint32_t pending_uptime = 0;
 
     for (;;) {
-        k_sleep(K_MSEC(CONFIG_LINKR_BLE_BRIDGE_WEBDAV_UPLOAD_INTERVAL_MS));
+        k_sleep(K_MSEC(WEBDAV_UPLOAD_INTERVAL_MS));
 
         if (!atomic_get(&wifi_connected) || !atomic_get(&wifi_ip_ready) ||
             !atomic_get(&webdav_configured)) {

--- a/web/app.js
+++ b/web/app.js
@@ -1222,7 +1222,7 @@ async function scanWifi() {
   elements.wifiFeedback.textContent = t("scanning");
   elements.wifiScanButton.disabled = true;
   clearTimeout(state.scanTimer);
-  state.scanTimer = setTimeout(finishScan, 10000);
+  state.scanTimer = setTimeout(finishScan, 50000);
   try {
     await sendControl(WIFI_SCAN_CMD);
     toast(t("scanning"));


### PR DESCRIPTION
…onnect

- Add esp32c5_devkitc_esp32c5_hpcore board conf/overlay: pure SRAM default (WiFi heap via locked kernel heap), PSRAM option kept commented with spinlock-patch caveat, tuned stacks/buffers from measured watermarks, 8s BLE supervision timeout to survive WiFi scan RF blackout.

- Add CONFIG_LINKR_BLE_BRIDGE_UART_RX_DROP_NO_CONN (default n, C5-only): drop Reliable UART retries when BLE is disconnected instead of blocking the UART RX thread, which starved the WS bridge in LAN-only mode. Data is staged to WS/log before the drop, so C3 keeps the original retry-until-reconnect semantics.

- ble_mgmt/wifi: replace queue-depth and stack-size literals with Kconfig options (defaults unchanged). - app.js: extend WiFi scan timeout to 50s. - .gitignore: ignore logs and temp scripts.